### PR TITLE
tasks/agent: Don't remove zones and constants conf

### DIFF
--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -34,12 +34,10 @@
     state: absent
   with_items:
     - conf.d
-    - constants.conf
     - features-available
     - features-enabled
     - pki
     - scripts
-    - zones.conf
     - zones.d
 
 - name: Create certs directory


### PR DESCRIPTION
They are not actually used, but package configuration on Debian fails
without their existence...